### PR TITLE
export parse function directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ Tests via [htmlparser-benchmark][2] are on the way.
 ## Usage
 
 ```js
-var parser = require('fasthtml');
-var root = HTMLParser.parse('<ul id="list"><li>Hello World</li></ul>');
+var parse = require('fasthtml');
+var root = parse('<ul id="list"><li>Hello World</li></ul>');
 
 ```
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,111 +2,110 @@ var getAttributes = require('./utils/getAttributes');
 var pattern = require('./pattern');
 var elements = require('./elements');
 
-/**
- * Parses HTML and returns a root element
- */
-module.exports = {
-    /**
-     * Parse a chunk of HTML source.
-     * @param  {string} data      html
-     * @return {HTMLElement}      root element
-     */
-    parse: function(data, createElementNode, createTextNode) {
 
-        if (arguments.length !== 3) {
-            return;
+ /**
+ * Parses HTML and returns a root element
+ * @param  {string} data      html
+ * @param {Function} createElementNode A factory function for ElementNodes
+ *                                     (must implement appendChild() method)
+ * @param {Function} createTextNode A factory function for TextNodes
+ * @return {HTMLElement}      root element
+ */
+module.exports = function parse(data, createElementNode, createTextNode) {
+
+    if (arguments.length !== 3) {
+        return;
+    }
+
+    var root = createElementNode(null, {});
+    var currentParent = root;
+    var stack = [root];
+    var lastTextPos = -1;
+
+    for (var match, text; match = pattern.markup.exec(data); ) {
+        var tag = match[0],
+            tagName = match[2],
+            attributeString = match[3],
+            isClosingTag = match[1],
+            isExplicitlySelfClosingTag = match[4],
+            isImplicitlySelfClosingTag = elements.selfClosing[match[2]];
+
+            var isSelfClosingTag = isExplicitlySelfClosingTag || isImplicitlySelfClosingTag;
+
+        if (lastTextPos > -1) {
+            if (lastTextPos + tag.length < pattern.markup.lastIndex) {
+                // if has content
+                text = data.substring(lastTextPos, pattern.markup.lastIndex - tag.length);
+                currentParent.appendChild(createTextNode(text));
+            }
         }
 
-        var root = createElementNode(null, {});
-        var currentParent = root;
-        var stack = [root];
-        var lastTextPos = -1;
+        lastTextPos = pattern.markup.lastIndex;
 
-        for (var match, text; match = pattern.markup.exec(data); ) {
-            var tag = match[0],
-                tagName = match[2],
-                attributeString = match[3],
-                isClosingTag = match[1],
-                isExplicitlySelfClosingTag = match[4],
-                isImplicitlySelfClosingTag = elements.selfClosing[match[2]];
+        if (tag[1] == '!') {
+            // this is a comment
+            continue;
+        }
 
-                var isSelfClosingTag = isExplicitlySelfClosingTag || isImplicitlySelfClosingTag;
+        if (!isClosingTag) {
+            // not </ tags
 
-            if (lastTextPos > -1) {
-                if (lastTextPos + tag.length < pattern.markup.lastIndex) {
-                    // if has content
-                    text = data.substring(lastTextPos, pattern.markup.lastIndex - tag.length);
+            if (isExplicitlySelfClosingTag !== true && elements.closedByOpening[currentParent.tagName]) {
+                if (elements.closedByOpening[currentParent.tagName][tagName]) {
+                    stack.pop();
+                    currentParent = stack[stack.length - 1];
+                }
+            }
+
+            currentParent = currentParent.appendChild(createElementNode(tagName, getAttributes(attributeString)));
+            stack.push(currentParent);
+
+            if (elements.blockText[tagName]) {
+                // a little test to find next </script> or </style> ...
+                var closeMarkup = '</' + tagName + '>';
+                var index = data.indexOf(closeMarkup, pattern.markup.lastIndex);
+
+                if (index == -1) {
+                    // there is no matching ending for the text element.
+                    text = data.substr(pattern.markup.lastIndex);
+                } else {
+                    text = data.substring(pattern.markup.lastIndex, index);
+                }
+                if (text.length > 0) {
                     currentParent.appendChild(createTextNode(text));
                 }
-            }
 
-            lastTextPos = pattern.markup.lastIndex;
-
-            if (tag[1] == '!') {
-                // this is a comment
-                continue;
-            }
-
-            if (!isClosingTag) {
-                // not </ tags
-
-                if (isExplicitlySelfClosingTag !== true && elements.closedByOpening[currentParent.tagName]) {
-                    if (elements.closedByOpening[currentParent.tagName][tagName]) {
-                        stack.pop();
-                        currentParent = stack[stack.length - 1];
-                    }
-                }
-
-                currentParent = currentParent.appendChild(createElementNode(tagName, getAttributes(attributeString)));
-                stack.push(currentParent);
-
-                if (elements.blockText[tagName]) {
-                    // a little test to find next </script> or </style> ...
-                    var closeMarkup = '</' + tagName + '>';
-                    var index = data.indexOf(closeMarkup, pattern.markup.lastIndex);
-
-                    if (index == -1) {
-                        // there is no matching ending for the text element.
-                        text = data.substr(pattern.markup.lastIndex);
-                    } else {
-                        text = data.substring(pattern.markup.lastIndex, index);
-                    }
-                    if (text.length > 0) {
-                        currentParent.appendChild(createTextNode(text));
-                    }
-
-                    if (index == -1) {
-                        lastTextPos = pattern.markup.lastIndex = data.length + 1;
-                    } else {
-                        lastTextPos = pattern.markup.lastIndex = index + closeMarkup.length;
-                        isClosingTag = true;
-                    }
-                }
-            }
-
-            if (isClosingTag || isSelfClosingTag) {
-                // </ or /> or <br> etc.
-                while (true) {
-                    if (currentParent.tagName == tagName) {
-                        stack.pop();
-                        currentParent = stack[stack.length - 1];
-                        break;
-                    } else {
-                        // Trying to close current tag, and move on
-                        if (elements.closedByClosing[currentParent.tagName]) {
-                            if (elements.closedByClosing[currentParent.tagName][tagName]) {
-                                stack.pop();
-                                currentParent = stack[stack.length - 1];
-                                continue;
-                            }
-                        }
-                        // Use aggressive strategy to handle unmatching markups.
-                        break;
-                    }
+                if (index == -1) {
+                    lastTextPos = pattern.markup.lastIndex = data.length + 1;
+                } else {
+                    lastTextPos = pattern.markup.lastIndex = index + closeMarkup.length;
+                    isClosingTag = true;
                 }
             }
         }
 
-        return root;
+        if (isClosingTag || isSelfClosingTag) {
+            // </ or /> or <br> etc.
+            while (true) {
+                if (currentParent.tagName == tagName) {
+                    stack.pop();
+                    currentParent = stack[stack.length - 1];
+                    break;
+                } else {
+                    // Trying to close current tag, and move on
+                    if (elements.closedByClosing[currentParent.tagName]) {
+                        if (elements.closedByClosing[currentParent.tagName][tagName]) {
+                            stack.pop();
+                            currentParent = stack[stack.length - 1];
+                            continue;
+                        }
+                    }
+                    // Use aggressive strategy to handle unmatching markups.
+                    break;
+                }
+            }
+        }
     }
+
+    return root;
 };

--- a/test/benchmark.js
+++ b/test/benchmark.js
@@ -1,4 +1,4 @@
-var parse = require('../').parse;
+var parse = require('../');
 var createElement = require('./lib/createElementNode');
 var createTextNode = require('./lib/createTextNode');
 

--- a/test/optimized.js
+++ b/test/optimized.js
@@ -1,4 +1,4 @@
-var parse = require('../').parse;
+var parse = require('../');
 var createElement = require('./lib/createElementNode');
 var createTextNode = require('./lib/createTextNode');
 

--- a/test/test-basic.js
+++ b/test/test-basic.js
@@ -1,12 +1,12 @@
 var assert = require('chai').assert;
 
-var parser = require('../');
+var parse = require('../');
 
 
 describe('Basic usage', function () {
     describe('when called without any arguments', function () {
         it('should return undefined', function () {
-            var returnVal = parser.parse();
+            var returnVal = parse();
             assert.equal(returnVal, undefined);
         });
     });

--- a/test/test-simple-html.js
+++ b/test/test-simple-html.js
@@ -1,6 +1,6 @@
 var assert = require('chai').assert;
 
-var parse = require('../').parse;
+var parse = require('../');
 var createElementNode = require('./lib/createElementNode');
 var createTextNode = require('./lib/createTextNode');
 


### PR DESCRIPTION
Since the parser exports only has the .parse method, we could export it directly.
